### PR TITLE
Implements changing a card from piles

### DIFF
--- a/src/solitario/game/card.js
+++ b/src/solitario/game/card.js
@@ -335,12 +335,6 @@ solitario.game.Card.prototype.getZIndex = function() {
 };
 
 
-/** @inheritDoc */
-solitario.game.Card.prototype.isDroppable = function() {
-
-};
-
-
 /**
  * Returns whether or not the card is revealed.
  *
@@ -372,6 +366,9 @@ solitario.game.Card.prototype.removeEventListenersByType = function(type) {
  * do nothing.
  */
 solitario.game.Card.prototype.returnToPile = function() {
+  if (this.pile) {
+    this.pile.disableDroppableIndicator();
+  }
   if (this.positionInPile) {
     this.setPosition(this.positionInPile);
   }
@@ -391,6 +388,11 @@ solitario.game.Card.prototype.returnToPile = function() {
  */
 solitario.game.Card.prototype.reveal = function() {
   goog.dom.classes.add(this.element_, solitario.game.Card.ClassNames_.REVEALED);
+  // Make it draggable when the animation finishes.
+  goog.events.listenOnce(this.element_, goog.events.EventType.TRANSITIONEND,
+      function(evnt) {
+        this.isDraggable = true;
+      }, false, this);
 };
 
 

--- a/src/solitario/game/card.js
+++ b/src/solitario/game/card.js
@@ -65,6 +65,12 @@ solitario.game.Card = function(el) {
       this.element_, solitario.game.Card.DataAttrs_.NUMBER);
 
   /**
+   * Reference to the pile that currently hold this card.
+   * @type {?solitario.game.Pile}
+   */
+  this.pile = null;
+
+  /**
    * Recorded position of the location of the card as assigned by the containing
    * pile.
    * @type {?goog.math.Coordinate}
@@ -254,6 +260,17 @@ solitario.game.Card.prototype.disableDroppableIndicator = function() {
 
 
 /**
+ * Detaches the card from its holding pile.
+ */
+solitario.game.Card.prototype.detachFromPile = function() {
+  if (this.pile) {
+    this.pile.pop();
+    this.pile = null;
+  }
+};
+
+
+/**
  * Enables the visual clue marking the card as a droppable region.
  */
 solitario.game.Card.prototype.enableDroppableIndicator = function() {
@@ -282,6 +299,16 @@ solitario.game.Card.prototype.getAbsoluteSize = function() {
       solitario.game.constants.Card.WIDTH,
       solitario.game.constants.Card.HEIGHT);
   return new goog.math.Size(absDimensions.x, absDimensions.y);
+};
+
+
+/**
+ * Gets the relative position of the card in the viewport, in ems.
+ *
+ * @return {goog.math.Coordinate} The relative position of the card.
+ */
+solitario.game.Card.prototype.getPosition = function() {
+  return solitario.game.utils.toRelativeUnits(this.getAbsolutePosition());
 };
 
 

--- a/src/solitario/game/constants.js
+++ b/src/solitario/game/constants.js
@@ -30,7 +30,8 @@ solitario.game.constants.Events = {
   DRAG_MOVE: 'dragMove',
   DRAG_START: 'dragStart',
   READY: 'ready',
-  STOCK_TAKEN: 'stockTaken'
+  STOCK_TAKEN: 'stockTaken',
+  WASTE_TAKEN: 'wasteTaken'
 };
 
 

--- a/src/solitario/game/game.js
+++ b/src/solitario/game/game.js
@@ -215,8 +215,9 @@ solitario.game.Game.prototype.onCardDragEnd_ = function(evnt) {
 
   // A drop target was found, move the card here.
   if (this.dropPile_) {
-    // TODO(ofir): Implement receiving drop.
     this.dropPile_.disableDroppableIndicator();
+    card.detachFromPile();
+    this.dropPile_.push(card);
     this.dropPile_ = null;
   } else {
     card.returnToPile();

--- a/src/solitario/game/game.js
+++ b/src/solitario/game/game.js
@@ -137,16 +137,22 @@ solitario.game.Game.prototype.init_ = function() {
 
 
 /**
- * Event handler for when a card is taken from the stock.
+ * Event handler triggered when a card must be moved from the stock to the
+ * waste, it can be due to a click on the stock or when a card is popped from
+ * the waste..
  *
  * @param {goog.events.Event} evnt The event object passed.
  * @private
  */
-solitario.game.Game.prototype.onStockTaken_ = function(evnt) {
+solitario.game.Game.prototype.moveCardFromStockToWaste_ = function(evnt) {
   // Remove card from stock.
   var card = this.stock_.pop();
-  // Add card to waste.
-  this.waste_.push(card);
+  if (card) {
+    // Add card to waste.
+    this.waste_.push(card);
+  }
+  // TODO(ofirp): Do something when the last card is pulled from the stock, such
+  // as a warning to the user or display an indicator on the empty stock.
 };
 
 
@@ -290,5 +296,7 @@ solitario.game.Game.prototype.start = function() {
 
   // Sets up listeners for game events.
   goog.events.listen(this.stock_, solitario.game.constants.Events.STOCK_TAKEN,
-                     this.onStockTaken_, false, this);
+                     this.moveCardFromStockToWaste_, false, this);
+  goog.events.listen(this.waste_, solitario.game.constants.Events.WASTE_TAKEN,
+                     this.moveCardFromStockToWaste_, false, this);
 };

--- a/src/solitario/game/game.js
+++ b/src/solitario/game/game.js
@@ -214,7 +214,7 @@ solitario.game.Game.prototype.onCardDragEnd_ = function(evnt) {
   card.straighten();
 
   // A drop target was found, move the card here.
-  if (this.dropPile_) {
+  if (this.dropPile_ && this.dropPile_ != card.pile) {
     this.dropPile_.disableDroppableIndicator();
     card.detachFromPile();
     this.dropPile_.push(card);

--- a/src/solitario/game/pile.js
+++ b/src/solitario/game/pile.js
@@ -107,11 +107,12 @@ solitario.game.Pile.prototype.calculateDroppableRegion = function() {
  * receive a drop.
  */
 solitario.game.Pile.prototype.disableDroppableIndicator = function() {
-  var topCard = this.getTopCard();
-  // If the pile has cards, remove indicator from the top card, otherwise use
+  // If the pile has cards, remove indicator from every card, otherwise use
   // the pile itself.
-  if (topCard) {
-    topCard.disableDroppableIndicator();
+  if (this.pile.length) {
+    for (var i = this.pile.length - 1; i >= 0; i--) {
+      this.pile[i].disableDroppableIndicator();
+    }
   } else {
     goog.dom.classes.remove(this.element_,
         solitario.game.Pile.ClassNames_.DROP_TARGET);
@@ -124,11 +125,12 @@ solitario.game.Pile.prototype.disableDroppableIndicator = function() {
  * receive a drop.
  */
 solitario.game.Pile.prototype.enableDroppableIndicator = function() {
-  var topCard = this.getTopCard();
-  // If the pile has cards, add the indicator top the top card, otherwise use
+  // If the pile has cards, add the indicator to every card, otherwise use
   // the pile itself.
-  if (topCard) {
-    topCard.enableDroppableIndicator();
+  if (this.pile.length) {
+    for (var i = this.pile.length - 1; i >= 0; i--) {
+      this.pile[i].enableDroppableIndicator();
+    }
   } else {
     goog.dom.classes.add(this.element_,
         solitario.game.Pile.ClassNames_.DROP_TARGET);
@@ -180,6 +182,16 @@ solitario.game.Pile.prototype.getZIndex = function() {
 
 
 /**
+ * Pops a new card from the pile.
+ *
+ * @return {?solitario.game.Card} The card popped from the pile.
+ */
+solitario.game.Pile.prototype.pop = function() {
+  return this.pile.pop();
+};
+
+
+/**
  * Pushes a new card in the pile and sets its position to the corresponding
  * place in the pile.
  *
@@ -204,14 +216,4 @@ solitario.game.Pile.prototype.push = function(card) {
         card.setZIndex(cardZIndex);
         card.zIndexInPile = cardZIndex;
       }, false, this);
-};
-
-
-/**
- * Pops a new card from the pile.
- *
- * @return {solitario.game.Card} The card popped from the pile.
- */
-solitario.game.Pile.prototype.pop = function() {
-  return this.pile.pop();
 };

--- a/src/solitario/game/pile.js
+++ b/src/solitario/game/pile.js
@@ -83,39 +83,6 @@ solitario.game.Pile.prototype.getAbsolutePosition_ = function() {
 
 
 /**
- * Gets the relative (ems) position of the Pile in the viewport.
- *
- * @return {goog.math.Coordinate} Relative position of the pile in the viewport.
- * @protected
- */
-solitario.game.Pile.prototype.getPosition = function() {
-  return solitario.game.utils.toRelativeUnits(this.getAbsolutePosition_());
-};
-
-
-/**
- * Gets the current z-index of the pile element.
- *
- * @return {number} z-index of the card element.
- * @protected
- */
-solitario.game.Pile.prototype.getZIndex = function() {
-  return parseInt(goog.style.getComputedZIndex(this.element_));
-};
-
-
-/**
- * Returns the top-most card without removing it from the pile, unlike pop().
- *
- * @return {?solitario.game.Card} The card on top of the pile.
- * @protected
- */
-solitario.game.Pile.prototype.getTopCard = function() {
-  return this.pile[this.pile.length - 1] || null;
-};
-
-
-/**
  * Calculates the region where cards can be dropped on to this pile.
  */
 solitario.game.Pile.prototype.calculateDroppableRegion = function() {
@@ -180,6 +147,39 @@ solitario.game.Pile.prototype.getDroppableRegion = function() {
 
 
 /**
+ * Gets the relative (ems) position of the Pile in the viewport.
+ *
+ * @return {goog.math.Coordinate} Relative position of the pile in the viewport.
+ * @protected
+ */
+solitario.game.Pile.prototype.getPosition = function() {
+  return solitario.game.utils.toRelativeUnits(this.getAbsolutePosition_());
+};
+
+
+/**
+ * Returns the top-most card without removing it from the pile, unlike pop().
+ *
+ * @return {?solitario.game.Card} The card on top of the pile.
+ * @protected
+ */
+solitario.game.Pile.prototype.getTopCard = function() {
+  return this.pile[this.pile.length - 1] || null;
+};
+
+
+/**
+ * Gets the current z-index of the pile element.
+ *
+ * @return {number} z-index of the card element.
+ * @protected
+ */
+solitario.game.Pile.prototype.getZIndex = function() {
+  return parseInt(goog.style.getComputedZIndex(this.element_));
+};
+
+
+/**
  * Pushes a new card in the pile and sets its position to the corresponding
  * place in the pile.
  *
@@ -187,6 +187,7 @@ solitario.game.Pile.prototype.getDroppableRegion = function() {
  */
 solitario.game.Pile.prototype.push = function(card) {
   this.pile.push(card);
+  card.pile = this;
   // Set the card on top of everything during the change of position.
   card.setZIndex(solitario.game.constants.MAX_ZINDEX);
   // Position card at 0,0 relative to the pile.

--- a/src/solitario/game/tableu.js
+++ b/src/solitario/game/tableu.js
@@ -71,6 +71,23 @@ solitario.game.Tableu.prototype.initialize = function(cards) {
 
 
 /**
+ * Pops a card from the Tableu.
+ *
+ * @return {?solitario.game.Card} The card popped from the tableu.
+ * @override
+ */
+solitario.game.Tableu.prototype.pop = function() {
+  var poppedCard = solitario.game.Tableu.superClass_.pop.call(this);
+  // Reveal the new top card if there is one.
+  var topCard = this.getTopCard();
+  if (topCard) {
+    topCard.reveal();
+  }
+  return poppedCard;
+};
+
+
+/**
  * Adds a new card to the tableu.
  *
  * @param {solitario.game.Card} card Card to be pushed.
@@ -89,7 +106,7 @@ solitario.game.Tableu.prototype.push = function(card) {
         solitario.game.Tableu.INTERCARD_DISTANCE_HIDDEN_;
 
     // Fan down the card.
-    var cardPosition = previousCard.positionInPile;
+    var cardPosition = previousCard.positionInPile.clone();
     cardPosition.y += intercardDistance;
     card.setPosition(cardPosition);
     card.positionInPile = cardPosition;

--- a/src/solitario/game/waste.js
+++ b/src/solitario/game/waste.js
@@ -27,6 +27,32 @@ goog.inherits(solitario.game.Waste, solitario.game.Pile);
 
 
 /**
+ * Dispatches an event indicating a card was taken from the waste.
+ *
+ * @param {goog.event.Event} evt The event dispatched.
+ * @private
+ */
+solitario.game.Waste.prototype.dispatchWasteTakenEvent_ = function(evt) {
+  var wasteTakenEvent = new goog.events.Event(
+      solitario.game.constants.Events.WASTE_TAKEN, this);
+  goog.events.dispatchEvent(this, wasteTakenEvent);
+};
+
+
+/**
+ * Pops a card from the Waste.
+ *
+ * @return {?solitario.game.Card} The card popped from the waste.
+ * @override
+ */
+solitario.game.Waste.prototype.pop = function() {
+  var poppedCard = solitario.game.Waste.superClass_.pop.call(this);
+  this.dispatchWasteTakenEvent_();
+  return poppedCard;
+};
+
+
+/**
  * Adds a new card on top of the waste.
  *
  * @param {solitario.game.Card} card Card to be pushed.


### PR DESCRIPTION
- It makes possible to change a card from pile to pile, but it doesn't enforce any game rules yet. NOTE: This will not work when trying to change cards in the middle of the pile, as this will be handled later when groups of cards is implemented. Trying to move a card in the middle will yield unexpected results.
- All revealed cards are now draggable
- Moves cards automatically from stock to waste when a card is removed from the waste.
