### PR TITLE
Removes mouseout listeners and creates mouseup listeners on document

### DIFF
--- a/src/solitario/game/card.js
+++ b/src/solitario/game/card.js
@@ -190,10 +190,11 @@ solitario.game.Card.prototype.mouseDown_ = function(evnt) {
 
   this.disableAnimation();
   this.showDraggingIndicator();
+
   this.addEventListener(goog.events.EventType.MOUSEUP, this.mouseUp_);
+  goog.events.listen(goog.dom.getDocument(), goog.events.EventType.MOUSEUP,
+                     this.mouseUp_, false, this);
   goog.events.listen(goog.dom.getDocument(), goog.events.EventType.MOUSEMOVE,
-                     this.mouseMove_, false, this);
-  goog.events.listen(goog.dom.getDocument(), goog.events.EventType.MOUSEOUT,
                      this.mouseMove_, false, this);
 
   var dragStartEvent = new goog.events.Event(
@@ -234,11 +235,12 @@ solitario.game.Card.prototype.mouseMove_ = function(evnt) {
  * @private
  */
 solitario.game.Card.prototype.mouseUp_ = function(evnt) {
+  this.removeEventListenersByType(goog.events.EventType.MOUSEUP);
+  goog.events.unlisten(goog.dom.getDocument(), goog.events.EventType.MOUSEUP,
+                       this.mouseUp_, false, this);
   goog.events.unlisten(goog.dom.getDocument(), goog.events.EventType.MOUSEMOVE,
                        this.mouseMove_, false, this);
-  goog.events.unlisten(goog.dom.getDocument(), goog.events.EventType.MOUSEOUT,
-                       this.mouseMove_, false, this);
-  this.removeEventListenersByType(goog.events.EventType.MOUSEUP);
+
   goog.dom.classes.remove(this.element_,
       solitario.game.constants.ClassNames.DRAGGING,
       solitario.game.constants.ClassNames.NO_ANIMATION);

--- a/src/solitario/game/cardgroup.js
+++ b/src/solitario/game/cardgroup.js
@@ -109,9 +109,9 @@ solitario.game.CardGroup.prototype.initialize_ = function() {
 
   this.topCard_.addEventListener(goog.events.EventType.MOUSEUP,
       goog.bind(this.mouseUp_, this));
+  goog.events.listen(goog.dom.getDocument(), goog.events.EventType.MOUSEUP,
+                     this.mouseUp_, false, this);
   goog.events.listen(goog.dom.getDocument(), goog.events.EventType.MOUSEMOVE,
-                     this.mouseMove_, false, this);
-  goog.events.listen(goog.dom.getDocument(), goog.events.EventType.MOUSEOUT,
                      this.mouseMove_, false, this);
 };
 
@@ -145,11 +145,11 @@ solitario.game.CardGroup.prototype.mouseMove_ = function(evnt) {
  * @private
  */
 solitario.game.CardGroup.prototype.mouseUp_ = function(evnt) {
+  this.topCard_.removeEventListenersByType(goog.events.EventType.MOUSEUP);
+  goog.events.unlisten(goog.dom.getDocument(), goog.events.EventType.MOUSEUP,
+                       this.mouseUp_, false, this);
   goog.events.unlisten(goog.dom.getDocument(), goog.events.EventType.MOUSEMOVE,
                        this.mouseMove_, false, this);
-  goog.events.unlisten(goog.dom.getDocument(), goog.events.EventType.MOUSEOUT,
-                       this.mouseMove_, false, this);
-  this.topCard_.removeEventListenersByType(goog.events.EventType.MOUSEUP);
 
   this.mouseDownPosition_ = null;
 


### PR DESCRIPTION
Removes mouseout listeners and creates mouseup listeners on document while dragging cards and groups.

Closes #19
